### PR TITLE
Patches: soft delete fields should not display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@govhawkdc/quarterback",
-  "version": "0.5.0",
-  "homepage": "https://govhawkdc.github.io/quarterback/?v=0.5.0",
+  "version": "0.5.1",
+  "homepage": "https://govhawkdc.github.io/quarterback/?v=0.5.1",
   "main": "lib/index.js",
   "files": [
     "lib"

--- a/src/lib/components/QuarterBackFields.js
+++ b/src/lib/components/QuarterBackFields.js
@@ -56,7 +56,7 @@ class QuarterBackFields extends React.Component<Props> {
     } = this.props
 
     const defaultValue = { label: selectPlaceholder, id: '' }
-    const values = [ defaultValue, ...fields.filter(f => !f.deleted) ]
+    const values = [ defaultValue, ...fields ]
 
     const addClass = styleClassMap.QuarterBackFields || ''
 

--- a/src/lib/utils/values.js
+++ b/src/lib/utils/values.js
@@ -102,23 +102,29 @@ function getInputValues (
 }
 
 function prepSelectValues (values, opts = {}) {
-  return values.map(({fields, id, label}) => {
-    const display = opts.labelFilter
-      ? opts.labelFilter(label, fields, id)
-      : label
-
-    if (fields) {
-      return {
-        fields: prepSelectValues(fields),
-        label: display
+  return values
+    .map(({deleted, fields, id, label}) => {
+      if (deleted) {
+        return null
       }
-    }
 
-    return {
-      label: display,
-      value: id
-    }
-  })
+      const display = opts.labelFilter
+        ? opts.labelFilter(label, fields, id)
+        : label
+
+      if (fields) {
+        return {
+          fields: prepSelectValues(fields),
+          label: display
+        }
+      }
+
+      return {
+        label: display,
+        value: id
+      }
+    })
+    .filter(v => v !== null)
 }
 
 export {


### PR DESCRIPTION
Patch bug where soft-deleted fields were still displaying when nested (e.g., nested opt group fields)